### PR TITLE
Fixes to have a working environment

### DIFF
--- a/Vagrant/Build/Vagrantfile
+++ b/Vagrant/Build/Vagrantfile
@@ -1,8 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# To setup the keyboard on the VM
+# see install-keymap from console-common package for details
+keyboard = 'br'
+
 Vagrant.configure('2') do |config|
-  config.vm.box = 'ubuntu/trusty64'
+  config.vm.box = 'arfreitas/rabbitmq'
 
   config.vm.define 'primary', primary: true do |primary|
     primary.vm.hostname = 'primary'
@@ -19,7 +23,9 @@ Vagrant.configure('2') do |config|
     primary.vm.network :forwarded_port, guest: 61613, host: 61613
     primary.vm.network :private_network, ip: '192.168.50.4'
     primary.vm.provision 'shell', path: 'build-primary.sh'
-    primary.vm.provision "file", source: 'erlang', destination: '/etc/apt/preferences.d/erlang'
+    primary.vm.provision 'shell', path: 'build-primary-vagrant.sh', privileged: false
+    primary.vm.provision 'shell', path: 'build-primary-ipython.sh'
+    primary.vm.provision 'shell', inline: 'install-keymap #{keyboard}'
   end
 
   config.vm.define 'secondary', autostart: false do |secondary|
@@ -27,6 +33,7 @@ Vagrant.configure('2') do |config|
     secondary.vm.network :forwarded_port, guest: 5672, host: 5673
     secondary.vm.network :private_network, ip: '192.168.50.5'
     secondary.vm.provision 'shell', path: 'build-secondary.sh'
+    secondary.vm.provision 'shell', inline: 'install-keymap #{keyboard}'
   end
 
 end

--- a/Vagrant/Build/Vagrantfile
+++ b/Vagrant/Build/Vagrantfile
@@ -19,6 +19,7 @@ Vagrant.configure('2') do |config|
     primary.vm.network :forwarded_port, guest: 61613, host: 61613
     primary.vm.network :private_network, ip: '192.168.50.4'
     primary.vm.provision 'shell', path: 'build-primary.sh'
+    primary.vm.provision "file", source: 'erlang', destination: '/etc/apt/preferences.d/erlang'
   end
 
   config.vm.define 'secondary', autostart: false do |secondary|

--- a/Vagrant/Build/build-primary-ipython.sh
+++ b/Vagrant/Build/build-primary-ipython.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Configuration file for ipython-notebook.
+mkdir -p /var/log/ipython
+mkdir -p /home/vagrant/.ipython/profile_default
+echo "c = get_config()
+
+c.InteractiveShell.autoindent = True
+c.NotebookApp.ip = '*'
+c.NotebookApp.port = 8888
+c.NotebookApp.open_browser = False
+c.NotebookApp.ipython_dir = u'/home/vagrant/.ipython'
+c.NotebookApp.notebook_dir = u'/opt/rabbitmq-in-depth/notebooks'
+c.ContentsManager.hide_globs = [u'__pycache__', '*.pyc', '*.pyo', '.DS_Store', '*.so', '*.dylib', '*~', 'ch6']
+" > /home/vagrant/.ipython/profile_default/ipython_notebook_config.py
+chown vagrant:vagrant -R /home/vagrant/.ipython
+
+echo "[Unit]
+Description=Jupyter Notebook Server
+
+[Service]
+Type=simple
+Environment="PATH=/home/vagrant/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
+ExecStart=/home/vagrant/venv/bin/python /home/vagrant/venv/bin/jupyter notebook
+User=vagrant
+Group=vagrant
+WorkingDirectory=/home/vagrant
+
+[Install]
+WantedBy=multi-user.target
+" > /etc/systemd/system/jupyter.service
+
+echo "[Unit]
+Description=Statelessd
+[Service]
+Type=simple
+Environment="PATH=/home/vagrant/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
+ExecStart=/home/vagrant/venv/bin/python /home/vagrant/venv/bin/tinman -c /etc/statelessd.yml -f
+User=vagrant
+Group=vagrant
+WorkingDirectory=/home/vagrant
+
+[Install]
+WantedBy=multi-user.target
+" > /etc/systemd/system/statelessd.service
+
+echo "%YAML 1.2
+---
+Daemon:
+  pidfile: /var/run/statelessd/statelessd.pid
+  user: nginx
+
+Application:
+  debug: False
+  xsrf_cookies: false
+  paths:
+    base: /usr/local/share/statelessd
+    static: static
+    templates: templates
+  rabbitmq:
+    host: localhost
+    port: 5672
+
+HTTPServer:
+  no_keep_alive: false
+  ports: [8900]
+  xheaders: false
+
+Routes:
+ - ['/([^/]+)/([^/]+)/([^/]+)', statelessd.Publisher]
+ - [/stats, statelessd.Stats]
+ - [/, statelessd.Dashboard]
+
+Logging:
+  version: 1
+  formatters:
+    verbose:
+      format: '%(levelname) -10s %(asctime)s %(processName)-20s %(name) -35s %(funcName) -30s: %(message)s'
+      datefmt: '%Y-%m-%d %H:%M:%S'
+    syslog:
+      format: '%(levelname)s <PID %(process)d:%(processName)s> %(name)s.%(funcName)s(): %(message)s'
+  filters: []
+  handlers:
+    console:
+      class: logging.StreamHandler
+      formatter: verbose
+      debug_only: false
+    syslog:
+      class: logging.handlers.SysLogHandler
+      facility: daemon
+      address: /dev/log
+      formatter: syslog
+  loggers:
+    clihelper:
+      level: WARNING
+      propagate: true
+      handlers: [console, syslog]
+    pika:
+      level: INFO
+      propagate: true
+      handlers: [console, syslog]
+    pika.adapters:
+      level: DEBUG
+      propagate: true
+      handlers: [console, syslog]
+    pika.connection:
+      level: DEBUG
+      propagate: true
+      handlers: [console, syslog]
+    statelessd:
+      level: INFO
+      propagate: true
+      handlers: [console, syslog]
+    tinman:
+      level: INFO
+      propagate: true
+      handlers: [console, syslog]
+    tornado:
+      level: WARNING
+      propagate: true
+      handlers: [console, syslog]
+  disable_existing_loggers: true
+  incremental: false
+" > /etc/statelessd.yml

--- a/Vagrant/Build/build-primary-vagrant.sh
+++ b/Vagrant/Build/build-primary-vagrant.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cd "${HOME}"
+virtualenv venv
+source "${HOME}/venv/bin/activate"
+pip install --upgrade pip
+
+echo "
+jinja2
+paho-mqtt
+nose
+pika
+pamqp
+pexpect
+pygments
+pyzmq
+jsonschema
+rabbitpy
+readline
+requests
+stomp.py
+statelessd
+tornado
+ipython
+jupyter
+"  > /tmp/requirements.pip
+pip install -r /tmp/requirements.pip
+rm /tmp/requirements.pip

--- a/Vagrant/Build/build-primary.sh
+++ b/Vagrant/Build/build-primary.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-echo "deb https://dl.bintray.com/rabbitmq/debian trusty main" | tee /etc/apt/sources.list.d/bintray.rabbitmq.list
-wget -O- https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc | apt-key add -
-
-apt-get update -qq
-apt-get remove -y -qq chef puppet
-apt-get autoremove -y -qq
-
 # Add the vagrant node primary addresses
 echo "
 # Vagrant Node Private Addresses
@@ -18,13 +11,12 @@ echo "
 export DEBIAN_FRONTEND=noninteractive
 
 # Install packages
-apt-get install -y -qq git rabbitmq-server python-pip python-dev ncurses-dev libjpeg8 python-imaging python-numpy python-opencv
+apt-get install -y git python-pip python-dev ncurses-dev libjpeg8 python-imaging python-numpy python-opencv virtualenv
 
 # Clean up apt-leftovers
-apt-get -qq -y remove curl unzip
+apt-get -y remove curl
 apt-get autoremove -y
 apt-get clean
-rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Stop the already running RabbitMQ server
 service rabbitmq-server stop
@@ -38,11 +30,19 @@ chown rabbitmq:rabbitmq /var/lib/rabbitmq/.erlang.cookie
 echo "[{rabbit, [{loopback_users, []}]}]." > /etc/rabbitmq/rabbitmq.config
 
 # Add the plugins
-PLUGINS=( rabbitmq_consistent_hash_exchange rabbitmq_management rabbitmq_management_visualiser rabbitmq_federation rabbitmq_federation_management rabbitmq_shovel rabbitmq_shovel_management rabbitmq_mqtt rabbitmq_stomp rabbitmq_tracing rabbitmq_web_stomp rabbitmq_web_stomp_examples rabbitmq_amqp1_0 )
+PLUGINS=(rabbitmq_consistent_hash_exchange rabbitmq_management
+rabbitmq_management_visualiser rabbitmq_federation rabbitmq_federation_management
+rabbitmq_shovel rabbitmq_shovel_management rabbitmq_mqtt rabbitmq_stomp
+rabbitmq_tracing rabbitmq_web_stomp rabbitmq_web_stomp_examples rabbitmq_amqp1_0)
+
 for plugin in "${PLUGINS[@]}"
 do
-  rabbitmq-plugins --offline enable ${plugin}
+    cmd="rabbitmq-plugins --offline enable ${plugin}"
+    echo "Executing '${cmd}'"
+    $cmd
 done
+
+service rabbitmq-server start
 
 # Get the RabbitMQ-In-Depth git repo
 mkdir -p /opt
@@ -50,144 +50,3 @@ if [ ! -d "/opt/rabbitmq-in-depth" ]; then
   git clone https://github.com/gmr/RabbitMQ-in-Depth.git /opt/rabbitmq-in-depth
 fi
 chown -R vagrant:vagrant /opt/rabbitmq-in-depth
-
-echo "
-jinja2
-mosquitto
-nose
-pika
-pamqp
-pexpect
-pygments
-pyzmq
-jsonschema
-rabbitpy
-readline
-requests
-stomp.py
-statelessd
-tornado
-ipython
-"  > /tmp/requirements.pip
-pip install -r /tmp/requirements.pip
-rm /tmp/requirements.pip
-
-
-# Configuration file for ipython-notebook.
-mkdir -p /var/log/ipython
-mkdir -p /home/vagrant/.ipython/profile_default
-echo "c = get_config()
-
-c.InteractiveShell.autoindent = True
-c.NotebookApp.ip = '*'
-c.NotebookApp.port = 8888
-c.NotebookApp.open_browser = False
-c.NotebookApp.ipython_dir = u'/home/vagrant/.ipython'
-c.NotebookApp.notebook_dir = u'/opt/rabbitmq-in-depth/notebooks'
-c.ContentsManager.hide_globs = [u'__pycache__', '*.pyc', '*.pyo', '.DS_Store', '*.so', '*.dylib', '*~', 'ch6']
-" > /home/vagrant/.ipython/profile_default/ipython_notebook_config.py
-chown vagrant:vagrant -R /home/vagrant/.ipython
-
-echo "# IPython Notebook Upstart Script
-respawn
-
-chdir /home/vagrant
-setuid vagrant
-
-start on runlevel [2345]
-stop on runlevel [06]
-
-exec ipython notebook --ipython-dir=/home/vagrant/.ipython
-" > /etc/init/ipython.conf
-
-echo "# Statelessd Upstart Script
-respawn
-
-start on runlevel [2345]
-stop on runlevel [06]
-
-exec /usr/local/bin/tinman -c /etc/statelessd.yml -f
-" > /etc/init/statelessd.conf
-
-echo "%YAML 1.2
----
-Daemon:
-  pidfile: /var/run/statelessd/statelessd.pid
-  user: nginx
-
-Application:
-  debug: False
-  xsrf_cookies: false
-  paths:
-    base: /usr/local/share/statelessd
-    static: static
-    templates: templates
-  rabbitmq:
-    host: localhost
-    port: 5672
-
-HTTPServer:
-  no_keep_alive: false
-  ports: [8900]
-  xheaders: false
-
-Routes:
- - ['/([^/]+)/([^/]+)/([^/]+)', statelessd.Publisher]
- - [/stats, statelessd.Stats]
- - [/, statelessd.Dashboard]
-
-Logging:
-  version: 1
-  formatters:
-    verbose:
-      format: '%(levelname) -10s %(asctime)s %(processName)-20s %(name) -35s %(funcName) -30s: %(message)s'
-      datefmt: '%Y-%m-%d %H:%M:%S'
-    syslog:
-      format: '%(levelname)s <PID %(process)d:%(processName)s> %(name)s.%(funcName)s(): %(message)s'
-  filters: []
-  handlers:
-    console:
-      class: logging.StreamHandler
-      formatter: verbose
-      debug_only: false
-    syslog:
-      class: logging.handlers.SysLogHandler
-      facility: daemon
-      address: /dev/log
-      formatter: syslog
-  loggers:
-    clihelper:
-      level: WARNING
-      propagate: true
-      handlers: [console, syslog]
-    pika:
-      level: INFO
-      propagate: true
-      handlers: [console, syslog]
-    pika.adapters:
-      level: DEBUG
-      propagate: true
-      handlers: [console, syslog]
-    pika.connection:
-      level: DEBUG
-      propagate: true
-      handlers: [console, syslog]
-    statelessd:
-      level: INFO
-      propagate: true
-      handlers: [console, syslog]
-    tinman:
-      level: INFO
-      propagate: true
-      handlers: [console, syslog]
-    tornado:
-      level: WARNING
-      propagate: true
-      handlers: [console, syslog]
-  disable_existing_loggers: true
-  incremental: false
-" > /etc/statelessd.yml
-
-service rabbitmq-server start
-service ipython start
-service statelessd start

--- a/Vagrant/Build/build-primary.sh
+++ b/Vagrant/Build/build-primary.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv F7B8CEA6056E8E56 && \
-echo "deb http://www.rabbitmq.com/debian/ testing main" > /etc/apt/sources.list.d/rabbitmq.list && \
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv D208507CA14F4FCA && \
-echo "deb http://packages.erlang-solutions.com/debian precise contrib" > /etc/apt/sources.list.d/erlang-solutions.list
+
+echo "deb https://dl.bintray.com/rabbitmq/debian trusty main" | tee /etc/apt/sources.list.d/bintray.rabbitmq.list
+wget -O- https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc | apt-key add -
+
 apt-get update -qq
 apt-get remove -y -qq chef puppet
 apt-get autoremove -y -qq

--- a/Vagrant/Build/build-secondary.sh
+++ b/Vagrant/Build/build-secondary.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv F7B8CEA6056E8E56 && \
-echo "deb http://www.rabbitmq.com/debian/ testing main" > /etc/apt/sources.list.d/rabbitmq.list && \
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv D208507CA14F4FCA && \
-echo "deb http://packages.erlang-solutions.com/debian precise contrib" > /etc/apt/sources.list.d/erlang-solutions.list
-apt-get update -qq
-apt-get remove -y -qq chef puppet
-apt-get autoremove -y -qq
 
 # Add the vagrant node primary addresses
 echo "
@@ -24,7 +17,7 @@ apt-get install -y -qq rabbitmq-server
 apt-get -qq -y remove curl unzip
 apt-get autoremove -y
 apt-get clean
-rm -rf /var/lib/{apt,dpkg,cache,log}/
+#rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Stop the already running RabbitMQ server
 service rabbitmq-server stop

--- a/Vagrant/base/README.md
+++ b/Vagrant/base/README.md
@@ -1,6 +1,6 @@
 # Artifacts to generate a base Vagrant image for RabbitMQ
 
-The files include in this directory is to provide an automated way to create base RabbitMQ images to be used for primary and secondary later.
+The files included in this directory is to provide an automated way to create base RabbitMQ images to be used for primary and secondary later.
 
 The Vagrantfile and setup.sh shell script will:
 

--- a/Vagrant/base/README.md
+++ b/Vagrant/base/README.md
@@ -1,0 +1,14 @@
+# Artifacts to generate a base Vagrant image for RabbitMQ
+
+The files include in this directory is to provide an automated way to create base RabbitMQ images to be used for primary and secondary later.
+
+The Vagrantfile and setup.sh shell script will:
+
+1. Update the Ubuntu Linux distribution.
+2. Download and install GPG keys from Erlang distribution.
+3. Download and install GPG keys from RabbitMQ distribution.
+4. Update the Ubuntu APT repositories and install the required software.
+
+This will ensure that all the basic required software to run a RabbitMQ server is in place and use the latest stable versions available.
+
+This current implementation is designed to work only with Virtualbox provider. New providers support could be added later.

--- a/Vagrant/base/Vagrantfile
+++ b/Vagrant/base/Vagrantfile
@@ -2,8 +2,10 @@
 # vi: set ft=ruby :
 
 Vagrant.configure('2') do |config|
-  config.vm.box = 'ubuntu/trusty64'
-  config.vm.provision 'shell', 'path': 'setup.sh' 
+  config.vm.box = 'ubuntu/xenial64'
+  config.vm.provision 'shell', 'path': 'setup.sh'
+  # inserting the insecure SSH key to force Vagrant to generate a new one
+  config.vm.provision 'shell', inline: 'curl https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub > /home/vagrant/.ssh/authorized_keys', privileged: false
 
   config.vm.provider "virtualbox" do |vb|
       vb.gui = false

--- a/Vagrant/base/Vagrantfile
+++ b/Vagrant/base/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'ubuntu/trusty64'
+  config.vm.provision 'shell', 'path': 'setup.sh' 
+
+  config.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.name = 'rabbitmq-base'
+  end
+end

--- a/Vagrant/base/setup.sh
+++ b/Vagrant/base/setup.sh
@@ -8,8 +8,10 @@ wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
 dpkg -i erlang-solutions_1.0_all.deb
 rm -v erlang-solutions_1.0_all.deb
 apt-get update
-apt-get remove -y -qq chef puppet
-apt-get autoremove -y -qq
+apt-get remove -y chef puppet
+apt-get autoremove -y
 apt-get -y upgrade
 apt-get -y install esl-erlang
-apt-get -y install rabbitmq-server
+apt-get -y install rabbitmq-server console-common
+apt-get autoremove -y
+apt-get clean

--- a/Vagrant/base/setup.sh
+++ b/Vagrant/base/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Let aptitude know it's a non-interactive install
+export DEBIAN_FRONTEND=noninteractive
+wget https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add -
+wget -O- https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc | apt-key add -
+wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
+dpkg -i erlang-solutions_1.0_all.deb
+rm -v erlang-solutions_1.0_all.deb
+apt-get update
+apt-get remove -y -qq chef puppet
+apt-get autoremove -y -qq
+apt-get -y upgrade
+apt-get -y install esl-erlang
+apt-get -y install rabbitmq-server


### PR DESCRIPTION
- Rabbitmq was not not being installed due the keys not being available anymore.
- Creating a base box which primary and secondary can be built over, instead of duplicating the steps.
- Installing a updated Erlang version in the processes too.
- The base box is now build on top of Ubuntu Xenial instead of Trusty, since newer versions of Python 
- Tornado module will not work on older versions of Python due lack of updated SSL/TLS version.
- Provisioning of primary and secondary now allow the configuration of keyboard mapping from the Vagrantfile.
- Broken down the build-primary.sh script to three scripts, to allow setting up a Python Virtualenv and installing all required modules over there. This gives more freedom to update modules without risking the Ubuntu OS and also allows to update the pip program (which had broken to install newer modules due too old version).
- The mosquitto Python module is not available in Pypi repository anymore and the project seems to be discontinued. It was replaced with paho-mqtt, but I'm not sure the compartibility between the modules interface, so something can be broken while evaluating RabbitMQ MQTT support.
- Replaced Upstart scripts related to running services with the corresponding configuration for Systemd. The old Upstart scripts were not working on Ubuntu Xenial.
-Small improvements to code readability.